### PR TITLE
Remove unused imports

### DIFF
--- a/cirq/contrib/routing/multi_prog_mapping.py
+++ b/cirq/contrib/routing/multi_prog_mapping.py
@@ -3,12 +3,9 @@
 import networkx as nx
 import numpy as np
 import math
-import copy
 
 import cirq
 import cirq.contrib.routing as ccr
-from cirq import circuits, ops, value
-from util import load_calibrations
 
 
 class Hierarchy_tree:


### PR DESCRIPTION
This allows to run tests: `pytest cirq/contrib/routing`